### PR TITLE
Fixed duplicate terms with pipes

### DIFF
--- a/app_code/cli/export_tn_tw_tq.py
+++ b/app_code/cli/export_tn_tw_tq.py
@@ -193,8 +193,9 @@ def get_tw_list(fr_id, page, book):
         return
 
     text = it_se.group(1).strip()
-    tw_list = [x.split('|')[0] for x in link_re.findall(text)]
-    tw_list += dw_link_re.findall(text)
+    #tw_list = [x.split('|')[0] for x in link_re.findall(text)]
+    #tw_list += dw_link_re.findall(text)
+    tw_list = [x.split('|')[0] for x in dw_link_re.findall(text)]
     # Add to catalog
     entry = {'id': fr,
              'items': [{'id': x} for x in tw_list]


### PR DESCRIPTION
Makes sure that terms with pipes in them (to have a title to the right) are included. Had to commented out the linkre because it seems dwlinkre also got the same terms, thus resulted in duplicates with pipes, such as in Psalm 093 chunk 01.